### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This MCP (Model Context Protocol) server provides tools for fetching and processing web content using Cloudflare Browser Rendering for use as context in LLMs. It's designed to work with both Claude and Cline client environments.
 
+<a href="https://glama.ai/mcp/servers/35u5mo3dm5">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/35u5mo3dm5/badge" alt="cloudflare-browser-rendering-mcp MCP server" />
+</a>
+
 ## Features
 
 - **Web Content Fetching**: Fetch and process web pages for LLM context


### PR DESCRIPTION
This PR adds a badge for the [cloudflare-browser-rendering-mcp](https://glama.ai/mcp/servers/35u5mo3dm5) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/35u5mo3dm5">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/35u5mo3dm5/badge" alt="cloudflare-browser-rendering-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.